### PR TITLE
Make library no_std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sht31"
 description = "A library for the SHT31 temperature and humidity sensor"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/FloppyDisck/SHT31-rs"
@@ -11,11 +11,10 @@ categories = ["embedded"]
 
 [features]
 esp32-fix = []
+thiserror = ["dep:thiserror"]
 
 [dependencies]
-embedded-svc            = "0.22.0"
 embedded-hal            = "0.2.7"
 
 crc = "3.0.0"
-anyhow = "1"
-thiserror = "1.0.38"
+thiserror = {version= "1.0.38", optional = true}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ the current thread until the sensor does a reading.
 use sht31::prelude::*;
 
 fn main() -> Result<()> {
-    // Requires an 12c connection only
-    let sht = SHT31::new(i2c);
+    // Requires an i2c connection + delay (both from embedded_hal::blocking)
+    let sht = SHT31::new(i2c, delay);
     
     loop {
         let reading = sht.read()?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,36 +1,35 @@
-use thiserror::Error;
+pub type Result<T> = core::result::Result<T, SHTError>;
 
-pub type Result<T> = std::result::Result<T, SHTError>;
-
-#[derive(Error, Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum SHTError {
-    #[error("Write Read I2C Error")]
+    #[cfg_attr(feature = "thiserror", error("Write Read I2C Error"))]
     WriteReadI2CError,
-    #[error("Write I2C Error")]
+    #[cfg_attr(feature = "thiserror", error("Write I2C Error")) ]
     WriteI2CError,
-    #[error("Humidity bytes [{bytes_start:#x}, {bytes_end:#x}] expected {expected_checksum:#x} but got the checksum {calculated_checksum:#x}")]
+    #[cfg_attr(feature = "thiserror", error("Humidity bytes [{bytes_start:#x}, {bytes_end:#x}] expected {expected_checksum:#x} but got the checksum {calculated_checksum:#x}"))]
     InvalidHumidityChecksumError {
         bytes_start: u8,
         bytes_end: u8,
         expected_checksum: u8,
         calculated_checksum: u8,
     },
-    #[error("Temperature bytes [{bytes_start:#x}, {bytes_end:#x}] expected {expected_checksum:#x} but got the checksum {calculated_checksum:#x}")]
+    #[cfg_attr(feature = "thiserror", error("Temperature bytes [{bytes_start:#x}, {bytes_end:#x}] expected {expected_checksum:#x} but got the checksum {calculated_checksum:#x}"))]
     InvalidTemperatureChecksumError {
         bytes_start: u8,
         bytes_end: u8,
         expected_checksum: u8,
         calculated_checksum: u8,
     },
-    #[error("Status bytes [{bytes_start:#x}, {bytes_end:#x}] expected {expected_checksum:#x} but got the checksum {calculated_checksum:#x}")]
+    #[cfg_attr(feature = "thiserror", error("Status bytes [{bytes_start:#x}, {bytes_end:#x}] expected {expected_checksum:#x} but got the checksum {calculated_checksum:#x}"))]
     InvalidStatusChecksumError {
         bytes_start: u8,
         bytes_end: u8,
         expected_checksum: u8,
         calculated_checksum: u8,
     },
-    #[error("Single shot reading timeout")]
+    #[cfg_attr(feature = "thiserror", error("Single shot reading timeout"))]
     ReadingTimeoutError,
-    #[error("This error should not happen")]
+    #[cfg_attr(feature = "thiserror", error("This error should not happen"))]
     PlaceholderError,
 }


### PR DESCRIPTION
Hey FloppyDisck,

I made some changes to your library to make it no_std compatible.

* Use `embedded_hal::blocking::delay::DelayMs` instead of `std::thread::sleep`
* Make thiserror dependency an optional feature

What do you think?