### PR TITLE
split i2c_read into read and write_read

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sht31"
 description = "A library for the SHT31 temperature and humidity sensor"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/FloppyDisck/SHT31-rs"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@ pub type Result<T> = core::result::Result<T, SHTError>;
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum SHTError {
+    #[cfg_attr(feature = "thiserror", error("Read I2C Error"))]
+    ReadI2CError,
     #[cfg_attr(feature = "thiserror", error("Write Read I2C Error"))]
     WriteReadI2CError,
     #[cfg_attr(feature = "thiserror", error("Write I2C Error"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ where
     pub fn status(&mut self) -> Result<Status> {
         let mut buffer = [0; 3];
 
-        self.i2c_read(&[0xF3, 0x2D], &mut buffer)?;
+        self.i2c_write_read(&[0xF3, 0x2D], &mut buffer)?;
 
         // Verify data
         let calculated = calculate_checksum(&Crc::<u8>::new(&CRC_ALGORITHM), buffer[0], buffer[1]);
@@ -308,7 +308,14 @@ where
         }
     }
 
-    fn i2c_read(&mut self, bytes: &[u8], buffer: &mut [u8]) -> Result<()> {
+    fn i2c_read(&mut self, buffer: &mut [u8]) -> Result<()> {
+        match self.i2c.read(self.address, buffer) {
+            Ok(res) => Ok(res),
+            Err(_) => Err(SHTError::ReadI2CError),
+        }
+    }
+
+    fn i2c_write_read(&mut self, bytes: &[u8], buffer: &mut [u8]) -> Result<()> {
         match self.i2c.write_read(self.address, bytes, buffer) {
             Ok(res) => Ok(res),
             Err(_) => Err(SHTError::WriteReadI2CError),

--- a/src/mode/periodic.rs
+++ b/src/mode/periodic.rs
@@ -60,7 +60,7 @@ where
     fn read(&mut self) -> Result<Reading> {
         let mut buffer = [0; 6];
 
-        self.i2c_read(&[0xE0, 0x00], &mut buffer)?;
+        self.i2c_write_read(&[0xE0, 0x00], &mut buffer)?;
         self.process_data(buffer)
     }
 }

--- a/src/mode/single_shot.rs
+++ b/src/mode/single_shot.rs
@@ -20,7 +20,7 @@ pub(crate) fn single_shot_read<Mode, I2C: I2c>(sensor: &mut SHT31<Mode, I2C>) ->
     // TODO: If error is a NACK then return another unique error to identify
     let mut buffer = [0; 6];
 
-    sensor.i2c_read(&[], &mut buffer)?;
+    sensor.i2c_read(&mut buffer)?;
     sensor.process_data(buffer)
 }
 


### PR DESCRIPTION
Using new esp-idf i2c interface, it is an error to use `write_read` with an empty send buffer. I split the read into single `read` and `read_write`. ~~I couldn't confirm if it works as it should after these changes.~~